### PR TITLE
Ingest: local Airflow DAG + robust price/news loaders (idempotent + logs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,12 @@ Thumbs.db
 _tree.txt
 # Dev reports
 scripts/dev/repo_audit_report.json
+
+
+# Local data & env
+data/
+*.db
+.env
+airflow_local/logs/
+airflow_local/plugins/
+airflow_local/__pycache__/

--- a/airflow/dags/marketsense_daily_ingest.py
+++ b/airflow/dags/marketsense_daily_ingest.py
@@ -1,0 +1,77 @@
+# airflow/dags/marketsense_daily_ingest.py
+"""
+MarketSense daily ingest DAG
+Order: fetch_prices -> fetch_news
+Runs your repo scripts inside the Airflow containers.
+
+Notes:
+- Your repo is mounted at /opt/marketsense in docker-compose.
+- We keep an optional venv activation (Linux layout) if you add one later.
+"""
+
+from datetime import datetime, timedelta
+from pathlib import Path
+import os
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+# --- Paths inside the container ------------------------------------------------
+# Repo is mounted to /opt/marketsense (see docker-compose).
+PROJECT_ROOT = Path(os.environ.get("PROJECT_ROOT", "/opt/marketsense")).resolve()
+
+# Optional: if you later create a venv in the repo (Linux layout), we’ll source it.
+VENV_ACTIVATE = PROJECT_ROOT / ".venv" / "bin" / "activate"
+
+# --- Environment passthrough (keeps keys out of logs) --------------------------
+ENV = {
+    "NEWS_API_KEY": os.environ.get("NEWS_API_KEY", ""),
+    # Add other env you want to pass through here
+}
+
+# --- DAG defaults --------------------------------------------------------------
+default_args = {
+    "owner": "marketsense",
+    "retries": 0,                       # set >0 after things are stable
+    "retry_delay": timedelta(minutes=5),
+}
+
+with DAG(
+    dag_id="marketsense_daily_ingest",
+    description="Run prices then news ingestion once daily",
+    default_args=default_args,
+    schedule="@daily",
+    start_date=datetime(2025, 8, 24),
+    catchup=False,                      # avoid backfilling while developing
+    dagrun_timeout=timedelta(minutes=30),
+    tags=["marketsense", "ingest"],
+) as dag:
+
+    # Safe bash prelude: pipefail + optional venv activation (Linux path)
+    bash_prelude = f"""
+set -euo pipefail
+if [ -f "{VENV_ACTIVATE}" ]; then
+  # Optional: use your project venv if you later add one to the image/volume
+  . "{VENV_ACTIVATE}"
+fi
+"""
+
+    fetch_prices = BashOperator(
+        task_id="fetch_prices",
+        bash_command=f"""
+{bash_prelude}
+python "{PROJECT_ROOT}/scripts/jobs/fetch_prices.py"
+""",
+        env=ENV,
+    )
+
+    fetch_news = BashOperator(
+        task_id="fetch_news",
+        bash_command=f"""
+{bash_prelude}
+python "{PROJECT_ROOT}/scripts/jobs/fetch_news.py" --mode daily
+""",
+        env=ENV,
+    )
+
+    fetch_prices >> fetch_news

--- a/airflow_local/docker-compose.yaml
+++ b/airflow_local/docker-compose.yaml
@@ -1,0 +1,78 @@
+version: "3.8"
+
+x-airflow-common: &airflow-common
+  build:
+    context: .
+    dockerfile: Dockerfile
+  environment: &airflow-env
+    # ---- Core ----
+    AIRFLOW__CORE__EXECUTOR: ${AIRFLOW__CORE__EXECUTOR:-SequentialExecutor}
+    AIRFLOW__CORE__FERNET_KEY: ${AIRFLOW__CORE__FERNET_KEY}
+    AIRFLOW__CORE__LOAD_EXAMPLES: "false"
+    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "true"
+    AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "true"
+    # make repo available to tasks
+    PYTHONPATH: /opt/marketsense
+    # pass your NewsAPI key through to tasks
+    NEWS_API_KEY: ${NEWS_API_KEY}
+  user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-0}"
+  working_dir: /opt/airflow
+  volumes:
+    # Airflow home (metadata DB, configs, logs)
+    - airflow_home:/opt/airflow
+    # DAGs from your repo
+    - ../airflow/dags:/opt/airflow/dags
+    # optional logs/plugins
+    - ./logs:/opt/airflow/logs
+    - ./plugins:/opt/airflow/plugins
+    # mount the whole repo so BashOperators can run your scripts and see your SQLite DB
+    - ..:/opt/marketsense
+
+services:
+  airflow-init:
+    <<: *airflow-common
+    entrypoint: /bin/bash
+    command:
+      - -c
+      - |
+        set -e
+        echo "Migrating metadata DB…"
+        airflow db migrate
+        echo "Creating admin user…"
+        airflow users create \
+          --username admin \
+          --firstname Ege \
+          --lastname Bayazit \
+          --role Admin \
+          --email ege.bayazit@gmail.com \
+          --password admin || true
+        echo "Init done."
+
+
+  scheduler:
+    <<: *airflow-common
+    depends_on:
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["airflow", "scheduler"]
+    ports:
+      - "8793:8793"
+
+  webserver:
+    <<: *airflow-common
+    depends_on:
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["airflow", "webserver"]
+    ports:
+      - "8080:8080"
+
+  triggerer:
+    <<: *airflow-common
+    depends_on:
+      airflow-init:
+        condition: service_completed_successfully
+    command: ["airflow", "triggerer"]
+
+volumes:
+  airflow_home:

--- a/scripts/dev/check_db.py
+++ b/scripts/dev/check_db.py
@@ -1,6 +1,23 @@
-# src/db/check_db.py
-from sqlalchemy import create_engine, inspect
+# scripts/dev/check_db.py
+from pathlib import Path
+from sqlalchemy import create_engine, inspect, text
 
-engine = create_engine("sqlite:///data/marketsense.db", future=True)
+DB_STR = "sqlite:///data/marketsense.db"
+
+print("cwd:", Path().resolve())
+print("DB URL:", DB_STR)
+print("DB exists on disk:", Path("data/marketsense.db").resolve().exists())
+
+engine = create_engine(DB_STR, future=True)
 insp = inspect(engine)
-print(insp.get_table_names())
+tables = insp.get_table_names()
+print("tables:", tables)
+
+# optional: row counts per table
+with engine.connect() as conn:
+    for t in tables:
+        try:
+            cnt = conn.execute(text(f"SELECT COUNT(*) FROM {t}")).scalar()
+            print(f"{t}: {cnt} rows")
+        except Exception as e:
+            print(f"{t}: error counting rows -> {e}")

--- a/scripts/jobs/fetch_news.py
+++ b/scripts/jobs/fetch_news.py
@@ -1,0 +1,384 @@
+# scripts/jobs/fetch_news.py
+"""
+Fetch recent news via NewsAPI and idempotently upsert into SQLite `news` table.
+
+Schema created if missing:
+  news(
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    headline     TEXT NOT NULL,
+    published_at TEXT NOT NULL,  -- ISO 8601 without timezone, e.g. 2025-08-21T14:05:00
+    source       TEXT,
+    url          TEXT UNIQUE
+  )
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sqlite3
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from dotenv import load_dotenv
+from newsapi import NewsApiClient
+
+# -------------------------
+# Logging
+# -------------------------
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+log = logging.getLogger(__name__)
+
+# -------------------------
+# Defaults / Config
+# -------------------------
+DEFAULT_DB_REL = Path("data/marketsense.db")
+
+LANG = "en"
+TOP_HEADLINES_COUNTRIES_DAILY = ["us"]
+TOP_HEADLINES_CATEGORIES = ["business", "technology", "general"]
+
+EVERYTHING_QUERIES = [
+    "economy OR inflation",
+    "markets OR stocks OR equities",
+    "interest rates OR central bank OR fed OR ECB",
+    "earnings OR quarterly results",
+    "technology OR AI OR artificial intelligence",
+    "energy OR oil OR gas OR renewables",
+]
+
+PAGE_SIZE = 100
+
+# No-op-safe UPSERT
+UPSERT_SQL = """
+INSERT INTO news (headline, published_at, source, url)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(url) DO UPDATE SET
+  headline     = excluded.headline,
+  published_at = excluded.published_at,
+  source       = excluded.source
+WHERE
+  COALESCE(news.headline,     '') != COALESCE(excluded.headline,     '')
+  OR COALESCE(news.published_at, '') != COALESCE(excluded.published_at, '')
+  OR COALESCE(news.source,     '') != COALESCE(excluded.source,     '');
+"""
+
+
+# -------------------------
+# Path / DB helpers
+# -------------------------
+def _is_airflow_container() -> bool:
+    # when running via our docker-compose the repo is mounted at /opt/marketsense
+    try:
+        return Path("/opt/marketsense").exists()
+    except Exception:
+        return False
+
+
+def resolve_db_path(cli_db: Optional[str]) -> Path:
+    """
+    Resolve DB path with precedence:
+      1) --db CLI
+      2) MARKETSENSE_DB env (absolute or relative to repo root)
+      3) default 'data/marketsense.db' under repo root
+
+    In Airflow, repo root is '/opt/marketsense'.
+    Locally, repo root is cwd (where you run the script), i.e. project root.
+    """
+    root = Path("/opt/marketsense") if _is_airflow_container() else Path.cwd()
+    env_db = os.getenv("MARKETSENSE_DB")
+
+    if cli_db:
+        p = Path(cli_db)
+        return p if p.is_absolute() else (root / p)
+
+    if env_db:
+        p = Path(env_db)
+        return p if p.is_absolute() else (root / p)
+
+    return root / DEFAULT_DB_REL
+
+
+def ensure_schema(con: sqlite3.Connection) -> None:
+    con.executescript(
+        """
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE IF NOT EXISTS news (
+          id           INTEGER PRIMARY KEY AUTOINCREMENT,
+          headline     TEXT NOT NULL,
+          published_at TEXT NOT NULL,
+          source       TEXT,
+          url          TEXT UNIQUE
+        );
+        CREATE INDEX IF NOT EXISTS idx_news_published_at
+          ON news(published_at DESC);
+        """
+    )
+
+
+# -------------------------
+# Time helpers
+# -------------------------
+def iso_no_tz(dt: datetime) -> str:
+    """
+    Format datetime as YYYY-MM-DDTHH:MM:SS with no timezone suffix.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    dt_utc = dt.astimezone(timezone.utc).replace(tzinfo=None, microsecond=0)
+    return dt_utc.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def normalize_published_at(value: Optional[str]) -> Optional[str]:
+    """
+    Normalize publishedAt strings from the API into YYYY-MM-DDTHH:MM:SS (no tz).
+    Accepts '2025-08-21T12:34:56Z' or '2025-08-21T12:34:56+00:00' variants.
+    """
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            dt = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+            return iso_no_tz(dt)
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return iso_no_tz(dt)
+        except ValueError:
+            pass
+        # Fallback: just date
+        dt = datetime.strptime(value[:10], "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        return iso_no_tz(dt)
+    except Exception:
+        return None
+
+
+# -------------------------
+# API call helpers
+# -------------------------
+def _normalize_article(a: Dict) -> Optional[Tuple[str, str, str, str]]:
+    """
+    Returns tuple (headline, published_at, source, url) or None if incomplete.
+    """
+    title = (a.get("title") or "").strip()
+    published_at = normalize_published_at(a.get("publishedAt"))
+    url = (a.get("url") or "").strip()
+    if not title or not published_at or not url:
+        return None
+    source_name = (a.get("source") or {}).get("name") or ""
+    return (title, published_at, source_name, url)
+
+
+def fetch_top_headlines(
+    client: NewsApiClient,
+    country: str,
+    category: str,
+    page_cap: int,
+    verbose: bool,
+) -> Optional[List[Dict]]:
+    """
+    Pull Top Headlines for a given (country, category).
+    Returns:
+      - list[articles] on success
+      - [] if empty page(s) / soft errors
+      - None if rateLimited (signals caller to stop whole run)
+    """
+    all_articles: List[Dict] = []
+    page = 1
+    while True:
+        try:
+            resp = client.get_top_headlines(
+                country=country, category=category, page=page, page_size=PAGE_SIZE
+            )
+        except Exception as e:
+            if verbose:
+                log.warning("top_headlines request error %s/%s page %s: %s", country, category, page, e)
+            time.sleep(1.0)
+            try:
+                resp = client.get_top_headlines(
+                    country=country, category=category, page=page, page_size=PAGE_SIZE
+                )
+            except Exception as e2:
+                if verbose:
+                    log.warning("top_headlines retry failed %s/%s page %s: %s", country, category, page, e2)
+                return []
+
+        if resp.get("status") != "ok":
+            if verbose:
+                log.warning("top_headlines non-ok %s/%s page %s: %s", country, category, page, resp)
+            if isinstance(resp, dict) and resp.get("code") == "rateLimited":
+                return None
+            return []
+
+        articles = resp.get("articles") or []
+        if not articles:
+            break
+        all_articles.extend(articles)
+
+        if len(articles) < PAGE_SIZE or page >= page_cap:
+            break
+        page += 1
+        time.sleep(0.1)
+    return all_articles
+
+
+def fetch_everything(
+    client: NewsApiClient,
+    query: str,
+    hours: int,
+    page_cap: int,
+    verbose: bool,
+) -> Optional[List[Dict]]:
+    """
+    Pull Everything for a broad query within a recent lookback window.
+    Returns list, [] if empty, None if rateLimited (caller should stop whole run).
+    """
+    to_dt = datetime.now(timezone.utc)
+    from_dt = to_dt - timedelta(hours=hours)
+    all_articles: List[Dict] = []
+    page = 1
+    while True:
+        params = dict(
+            q=query,
+            from_param=iso_no_tz(from_dt),
+            to=iso_no_tz(to_dt),
+            language=LANG,
+            sort_by="publishedAt",
+            page=page,
+            page_size=PAGE_SIZE,
+        )
+        try:
+            resp = client.get_everything(**params)
+        except Exception as e:
+            if verbose:
+                log.warning("everything request error [%s] page %s: %s", query, page, e)
+            time.sleep(1.0)
+            try:
+                resp = client.get_everything(**params)
+            except Exception as e2:
+                if verbose:
+                    log.warning("everything retry failed [%s] page %s: %s", query, page, e2)
+                return []
+
+        if resp.get("status") != "ok":
+            if verbose:
+                log.warning("everything non-ok [%s] page %s: %s", query, page, resp)
+            if isinstance(resp, dict) and resp.get("code") == "rateLimited":
+                return None
+            return []
+
+        articles = resp.get("articles") or []
+        if not articles:
+            break
+        all_articles.extend(articles)
+
+        if len(articles) < PAGE_SIZE or page >= page_cap:
+            break
+        page += 1
+        time.sleep(0.1)
+    return all_articles
+
+
+# -------------------------
+# Main
+# -------------------------
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["daily", "backfill"], default="daily")
+    parser.add_argument("--db", help="Override DB path (absolute or relative to repo root)")
+    args = parser.parse_args()
+
+    # Mode knobs (keep daily gentle for free tier; widen on backfill)
+    if args.mode == "backfill":
+        countries = ["us", "gb", "tr"]
+        page_cap = 3
+        window_hours = 48
+        verbose = True
+    else:
+        countries = TOP_HEADLINES_COUNTRIES_DAILY
+        page_cap = 1
+        window_hours = 24
+        verbose = False
+
+    # Env & API
+    load_dotenv()
+    api_key = os.getenv("NEWS_API_KEY")
+    if not api_key:
+        raise RuntimeError("Missing NEWS_API_KEY in environment (set it in your .env).")
+    client = NewsApiClient(api_key=api_key)
+
+    # DB setup
+    db_path = resolve_db_path(args.db)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    log.info("Connecting to database at %s", db_path)
+
+    # Collect
+    rate_limited = False
+    dedup_urls: set[str] = set()
+    rows: List[Tuple[str, str, str, str]] = []
+
+    # 1) Top Headlines breadth sweep
+    for country in countries:
+        if rate_limited:
+            break
+        for category in TOP_HEADLINES_CATEGORIES:
+            arts = fetch_top_headlines(client, country, category, page_cap=page_cap, verbose=verbose)
+            if arts is None:
+                log.warning("Rate-limited during top_headlines; stopping.")
+                rate_limited = True
+                break
+            if verbose:
+                log.info("top_headlines[%s/%s]: %d", country, category, len(arts))
+            for a in arts:
+                tup = _normalize_article(a)
+                if not tup:
+                    continue
+                h, pub, src, url = tup
+                if url in dedup_urls:
+                    continue
+                dedup_urls.add(url)
+                rows.append((h, pub, src, url))
+
+    # 2) Everything thematic sweep
+    if not rate_limited:
+        for q in EVERYTHING_QUERIES:
+            arts = fetch_everything(client, q, hours=window_hours, page_cap=page_cap, verbose=verbose)
+            if arts is None:
+                log.warning("Rate-limited during everything; stopping.")
+                rate_limited = True
+                break
+            if verbose:
+                log.info("everything[%s]: %d", q, len(arts))
+            for a in arts:
+                tup = _normalize_article(a)
+                if not tup:
+                    continue
+                h, pub, src, url = tup
+                if url in dedup_urls:
+                    continue
+                dedup_urls.add(url)
+                rows.append((h, pub, src, url))
+
+    # Upsert
+    changed = 0
+    with sqlite3.connect(db_path) as con:
+        ensure_schema(con)
+        if rows:
+            cur = con.cursor()
+            cur.executemany(UPSERT_SQL, rows)
+            changed = cur.rowcount or 0
+        con.commit()
+
+    if rate_limited:
+        log.warning("⚠️ Stopped early due to NewsAPI rate limit.")
+    log.info("✅ Total news upserted/updated: %d (processed=%d, unique urls=%d)", changed, len(rows), len(dedup_urls))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/jobs/fetch_prices.py
+++ b/scripts/jobs/fetch_prices.py
@@ -1,0 +1,259 @@
+# scripts/jobs/fetch_prices.py
+"""
+Fetch recent daily prices for a small watchlist via yfinance and
+idempotently upsert into SQLite `stocks` table.
+
+Expected schema (see db/sqlite/001_init.sql):
+  stocks(
+    ticker TEXT NOT NULL,
+    date   TEXT NOT NULL,           -- ISO YYYY-MM-DD
+    open   REAL, high REAL, low REAL,
+    close  REAL NOT NULL,
+    volume INTEGER DEFAULT 0 CHECK (volume >= 0),
+    PRIMARY KEY (ticker, date)
+  )
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Sequence
+import logging
+import re
+import sqlite3
+
+import pandas as pd
+import yfinance as yf
+
+# --------------------------------------------------------------------------------------
+# Paths: always relative to repo root (…/scripts/jobs/fetch_prices.py -> parents[2])
+# --------------------------------------------------------------------------------------
+ROOT = Path(__file__).resolve().parents[2]
+DB_PATH = ROOT / "data" / "marketsense.db"
+INIT_SQL = ROOT / "db" / "sqlite" / "001_init.sql"
+
+# --------------------------------------------------------------------------------------
+# Config
+# --------------------------------------------------------------------------------------
+TICKERS: list[str] = ["AAPL", "MSFT"]
+DAYS: int = 10  # pull a small rolling window
+
+# SQLite UPSERT (PK = (ticker, date))
+UPSERT_SQL = """
+INSERT INTO stocks (ticker, date, open, high, low, close, volume)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(ticker, date) DO UPDATE SET
+  open   = excluded.open,
+  high   = excluded.high,
+  low    = excluded.low,
+  close  = excluded.close,
+  volume = excluded.volume
+WHERE
+  COALESCE(stocks.open,   -1.0) != COALESCE(excluded.open,   -1.0) OR
+  COALESCE(stocks.high,   -1.0) != COALESCE(excluded.high,   -1.0) OR
+  COALESCE(stocks.low,    -1.0) != COALESCE(excluded.low,    -1.0) OR
+  COALESCE(stocks.close,  -1.0) != COALESCE(excluded.close,  -1.0) OR
+  COALESCE(stocks.volume, -1   ) != COALESCE(excluded.volume, -1   );
+"""
+
+# --------------------------------------------------------------------------------------
+# Logging
+# --------------------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+log = logging.getLogger("fetch_prices")
+
+
+# --------------------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------------------
+_non_alnum = re.compile(r"[^a-z0-9]+")
+
+
+def _norm(s: str) -> str:
+    """lowercase and strip non-alphanumerics -> helps match yfinance weird col names"""
+    return _non_alnum.sub("", s.lower())
+
+
+def _first_match(
+    columns: Sequence[str],
+    want: Sequence[str],
+    prefer_suffix: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Find first column whose normalized name starts with one of `want`.
+    If `prefer_suffix` is provided (e.g., the ticker), prefer a column that ends with that.
+    """
+    norm_map = {c: _norm(c) for c in columns}
+    # prefer “*_TICKER” if present
+    if prefer_suffix:
+        pref = prefer_suffix.lower()
+        for c, n in norm_map.items():
+            if any(n.startswith(_norm(w)) for w in want) and n.endswith(pref):
+                return c
+    # fallback: any matching start
+    for c, n in norm_map.items():
+        if any(n.startswith(_norm(w)) for w in want):
+            return c
+    return None
+
+
+def ensure_schema(con: sqlite3.Connection) -> None:
+    """Create tables if needed using INIT_SQL."""
+    cur = con.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='stocks';"
+    )
+    exists = cur.fetchone() is not None
+    if exists:
+        return
+    if INIT_SQL.exists():
+        log.info("stocks table missing — applying schema from %s", INIT_SQL)
+        with open(INIT_SQL, "r", encoding="utf-8") as f:
+            con.executescript(f.read())
+        log.info("Schema applied.")
+    else:
+        # minimalist create if init file is not present for any reason
+        log.warning(
+            "Init SQL not found at %s — creating minimal stocks table inline.",
+            INIT_SQL,
+        )
+        con.executescript(
+            """
+            PRAGMA foreign_keys=ON;
+            CREATE TABLE IF NOT EXISTS stocks (
+              ticker  TEXT NOT NULL,
+              date    TEXT NOT NULL,
+              open    REAL, high REAL, low REAL,
+              close   REAL NOT NULL,
+              volume  INTEGER DEFAULT 0 CHECK (volume >= 0),
+              PRIMARY KEY (ticker, date)
+            );
+            """
+        )
+
+
+def fetch_daily_window(ticker: str, days: int = DAYS) -> pd.DataFrame:
+    """
+    Download recent daily OHLCV and normalize columns/types.
+    Robust to MultiIndex/tuple columns and suffixed names like 'Close_AAPL'.
+    """
+    df = yf.download(
+        ticker,
+        period=f"{days}d",
+        interval="1d",
+        auto_adjust=False,   # be explicit (yfinance changed defaults)
+        progress=False,
+    )
+    if df is None or df.empty:
+        log.warning("No data returned for %s", ticker)
+        return pd.DataFrame()
+
+    # Flatten to simple columns
+    df = df.reset_index()
+    if isinstance(df.columns, pd.MultiIndex) or any(isinstance(c, tuple) for c in df.columns):
+        flat_cols = []
+        for c in df.columns:
+            if isinstance(c, tuple):
+                flat_cols.append("_".join([str(x) for x in c if x is not None]).strip())
+            else:
+                flat_cols.append(str(c))
+        df.columns = flat_cols
+    else:
+        df.columns = [str(c) for c in df.columns]
+
+    log.info("%s columns: %s", ticker, list(df.columns))
+
+    # Resolve columns (handle e.g. Close_AAPL, Adj Close_AAPL)
+    date_col = _first_match(df.columns, ["date", "datetime"]) or "Date"
+    open_col = _first_match(df.columns, ["open"], ticker)
+    high_col = _first_match(df.columns, ["high"], ticker)
+    low_col = _first_match(df.columns, ["low"], ticker)
+    # Prefer true Close over Adj Close if both exist
+    close_col = (
+        _first_match(df.columns, ["close"], ticker)
+        or _first_match(df.columns, ["adj close", "adj_close"], ticker)
+    )
+    volume_col = _first_match(df.columns, ["volume"], ticker)
+
+    if close_col is None:
+        log.warning("No close/adj close column found for %s; skipping", ticker)
+        return pd.DataFrame()
+
+    out = pd.DataFrame(
+        {
+            "date": pd.to_datetime(df[date_col]).dt.strftime("%Y-%m-%d"),
+            "open": df[open_col] if open_col in df.columns else None,
+            "high": df[high_col] if high_col in df.columns else None,
+            "low": df[low_col] if low_col in df.columns else None,
+            "close": df[close_col],
+            "volume": df[volume_col] if volume_col in df.columns else 0,
+        }
+    )
+    out["ticker"] = ticker
+
+    # Clean types / constraints
+    out = out.dropna(subset=["close"])
+    out["close"] = pd.to_numeric(out["close"], errors="coerce").fillna(0).clip(lower=0)
+
+    for col in ["open", "high", "low"]:
+        if col in out.columns:
+            out[col] = pd.to_numeric(out[col], errors="coerce")
+            # keep NaNs as NULLs, otherwise clip negatives
+            out[col] = out[col].where(out[col].isna(), out[col].clip(lower=0))
+
+    out["volume"] = (
+        pd.to_numeric(out["volume"], errors="coerce")
+        .fillna(0)
+        .astype("int64")
+        .clip(lower=0)
+    )
+
+    # Ensure low <= high when both present
+    if "low" in out.columns and "high" in out.columns:
+        mask = out["low"].notna() & out["high"].notna() & (out["low"] > out["high"])
+        if mask.any():
+            swapped = int(mask.sum())
+            low_vals = out.loc[mask, "low"].copy()
+            out.loc[mask, "low"] = out.loc[mask, "high"].values
+            out.loc[mask, "high"] = low_vals.values
+            log.debug("Swapped %d rows to enforce low<=high for %s", swapped, ticker)
+
+    log.info("Normalized frame for %s has %d rows", ticker, len(out))
+    return out[["ticker", "date", "open", "high", "low", "close", "volume"]]
+
+
+def upsert_df(con: sqlite3.Connection, df: pd.DataFrame) -> int:
+    """Bulk UPSERT rows; returns number of rows inserted/updated (SQLite rowcount)."""
+    if df.empty:
+        return 0
+    rows = [tuple(r) for r in df.itertuples(index=False, name=None)]
+    cur = con.cursor()
+    cur.executemany(UPSERT_SQL, rows)
+    return cur.rowcount or 0
+
+
+def main() -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    log.info("Connecting to database at %s", DB_PATH)
+
+    total = 0
+    with sqlite3.connect(DB_PATH) as con:
+        con.execute("PRAGMA foreign_keys = ON;")
+        ensure_schema(con)
+
+        for t in TICKERS:
+            log.info("Fetching %d days for %s", DAYS, t)
+            df = fetch_daily_window(t, days=DAYS)
+            up = upsert_df(con, df)
+            total += up
+            log.info("%s: upserted/updated %d", t, up)
+
+        con.commit()
+
+    log.info("✅ Total upserted/updated rows: %d", total)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR wires up a working local ingestion loop:

- Airflow DAG `marketsense_daily_ingest` with tasks:
  - `fetch_prices` → AAPL/MSFT daily OHLCV → SQLite `stocks`
  - `fetch_news` → dedup headlines → SQLite `news`
- Hardened scripts with structured logging, normalization, retries, and true-change UPSERTs.
- SQLite schema and helper dev script to inspect/clear data.
- Docker compose passes NEWS_API_KEY from .env; bind-mounts repo so tasks write to host DB.

Tested via manual triggers. Current counts after a clean run: stocks≈20, news≈97.
